### PR TITLE
Declare loop variable before fade-out loop

### DIFF
--- a/src/psgtest.c
+++ b/src/psgtest.c
@@ -106,7 +106,8 @@ int main(void)
     sn_set_volume(3, 15);   /* silence noise */
 
     /* Fade out */
-    for (unsigned v = 4; v <= 15; ++v) {
+    unsigned v;
+    for (v = 4; v <= 15; ++v) {
         sn_set_volume(0, v);
         sn_set_volume(1, v);
         sn_set_volume(2, v);


### PR DESCRIPTION
## Summary
- pre-declare fade-out loop variable and use existing variable in for loop

## Testing
- `gcc -c src/psgtest.c` *(fails: fatal error: dos.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e462696083258790d7b659a2c701