### PR TITLE
Use volatile tick pointer for BIOS counter

### DIFF
--- a/src/psgtest.c
+++ b/src/psgtest.c
@@ -40,7 +40,7 @@ static void sn_set_noise(unsigned mode)
 /* --- Timing using BIOS tick counter --- */
 static unsigned long get_ticks(void)
 {
-    unsigned long far *ticks = (unsigned long far*)MK_FP(BDA_SEG, BDA_TICKS_OFF);
+    volatile unsigned long far *ticks = (unsigned long far*)MK_FP(BDA_SEG, BDA_TICKS_OFF);
     return *ticks;
 }
 


### PR DESCRIPTION
## Summary
- mark BIOS tick pointer volatile in get_ticks()

## Testing
- `gcc -m32 -c src/psgtest.c` (fails: expected '=', ',', ';', 'asm' or '__attribute__' before '_cdecl')

------
https://chatgpt.com/codex/tasks/task_e_68b8c83d11b883259b0ed96448d25f51