### PR TITLE
Handle zero frequency in freq_to_period

### DIFF
--- a/src/psgtest.c
+++ b/src/psgtest.c
@@ -60,6 +60,10 @@ static void wait_ms(unsigned ms)
 static unsigned freq_to_period(unsigned freq_hz)
 {
     const unsigned long CLK = 3579545UL; /* verify on your board if needed */
+    if (freq_hz == 0) {
+        /* 0 Hz indicates silence; return max period to avoid divide-by-zero */
+        return 1023;
+    }
     unsigned long n = (CLK / 32UL) / (unsigned long)freq_hz;
     if (n < 1UL) n = 1UL;
     if (n > 1023UL) n = 1023UL;


### PR DESCRIPTION
## Summary
- Avoid divide-by-zero in `freq_to_period` by returning max period when frequency is zero.

## Testing
- `gcc -c src/psgtest.c` *(fails: fatal error: dos.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cc8a04708325b4aca2f8b8633e7f