### PR TITLE
Use psgtest source in build script

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -2,6 +2,5 @@
 set PATH=C:\BIN;C:\WINDOWS;C:\DOS
 set LIB=C:\LIB;C:\INCLUDE;C:\DDK\286\LIB
 set INCLUDE=C:\INCLUDE;C:\DDK\286\INC
-masm ADDNUM.ASM,ADDNUM.OBJ,,; > MASM.TXT
-cl /nologo /c /FoHELLOWOR.OBJ HELLOWOR.C > COMPILER.TXT
-echo. | link HELLOWOR.OBJ ADDNUM.OBJ,HELLOWOR.EXE,,; > LINKER.TXT
+cl /nologo /c /O /AS src\psgtest.c > output.txt
+echo. | link /NOI psgtest.obj,psgtest.exe,,; > link.txt


### PR DESCRIPTION
## Summary
- Build `psgtest` instead of nonexistent `HELLOWOR` example

## Testing
- `bash build.bat` *(fails: `cl: command not found` – MS-DOS toolchain unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68bb874fffc4832598ae28cbcf00a730