### PR TITLE
Build script adds WAVHYB test program

### DIFF
--- a/BUILD.BAT
+++ b/BUILD.BAT
@@ -5,5 +5,7 @@ set INCLUDE=C:\INCLUDE;C:\DDK\286\INC;C:\DDK\MULTIMED\INC
 del *.EXE *.OBJ *.DRV *.TXT
 cl /nologo /c /O /AS src\PSGTEST.C > OUTPUT.TXT
 echo. | link /NOI PSGTEST.OBJ,PSGTEST.EXE,,; > LINK.TXT
+cl /nologo /c /O /AS src\WAVHYB.C >> OUTPUT.TXT
+echo. | link /NOI WAVHYB.OBJ,WAVHYB.EXE,,; >> LINK.TXT
 cl /nologo /c /AS /Gs src\MIDIMAP.C >> OUTPUT.TXT
 link /NOD MIDIMAP.OBJ,MIDIMAP.DRV,,,src\MIDIMAP.DEF >> LINK.TXT


### PR DESCRIPTION
## Summary
- extend BUILD.BAT to compile and link WAVHYB test player

## Testing
- `dosbox-x -c "mount c /workspace/oemsound-tandy" -c "c:" -c "set PATH=C:\\BIN" -c "set LIB=C:\\LIB" -c "set INCLUDE=C:\\INCLUDE" -c "del *.EXE *.OBJ *.DRV *.TXT" -c "build" -c "dir > DIR.TXT" -c "psgtest > NUL" -c "wavhyb CHORD.WAV > NUL" -c "exit"`
- `dosbox-x -c "mount c /workspace/oemsound-tandy" -c "c:" -c "psgtest > NUL" -c "echo OK>PSGTEST.OK" -c "wavhyb CHORD.WAV > NUL" -c "echo OK>WAVHYB.OK" -c "exit"`


------
https://chatgpt.com/codex/tasks/task_e_68bf90b5849c8325922cb5200305dde3